### PR TITLE
Remove slashes in csv_filename to avoid path bugs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name="wikitablescrape",
-    version="1.0.2",
+    version="1.0.3",
     author="Andy Roche",
     author_email="andy@roche.io",
     description="Scrape HTML tables from a Wikipedia page into CSV format.",

--- a/wikitablescrape/parse.py
+++ b/wikitablescrape/parse.py
@@ -225,6 +225,6 @@ def reverse_enum(iterable):
 def csv_filename(text):
     """Return a normalized filename from a table header for outputting CSV."""
     text = text.lower()
-    text = re.sub(r"[,|'|\"]", "", text)
+    text = re.sub(r"[,|'|\"/]", "", text)
     text = re.sub(r"[\(|\)|-]", " ", text)
     return "_".join(text.split()) + ".csv"

--- a/wikitablescrape/test_parse.py
+++ b/wikitablescrape/test_parse.py
@@ -163,6 +163,17 @@ class TestFindTablesByHeader(unittest.TestCase):
             self.assert_table_found("table", "", html)
 
 
+class TestCsvFilename(unittest.TestCase):
+    def test_expected_filenames(self):
+        """Table headers are translated to OS-friendly filenames."""
+        testcases = [
+            ("General", "general.csv"),
+            ("API / editor features", "api_editor_features.csv"),
+        ]
+        for header, expected in testcases:
+            self.assertEqual(expected, parse.csv_filename(header))
+
+
 def text_html_table(caption=None):
     """Return a text HtmlTable with a given caption for testing."""
     if caption:


### PR DESCRIPTION
Fixes https://github.com/rocheio/wiki-table-scrape/issues/6.

```
$ wikitablescrape --url="https://en.wikipedia.org/wiki/Comparison_of_file_comparison_tools#Other_features" --output-folder=.
Parsing all tables from 'https://en.wikipedia.org/wiki/Comparison_of_file_comparison_tools#Other_features' into '.'
Writing table 1 to ./general.csv
Writing table 2 to ./compare_features.csv
Writing table 3 to ./api_editor_features.csv
Writing table 4 to ./other_features.csv
Writing table 5 to ./aspects.csv
```